### PR TITLE
[1.0.5] fix cordova plugin to work with berbix-android 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "berbix-cordova-plugin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Cordova plugin for using the Berbix Verify flow.",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="berbix-cordova-plugin" version="1.0.4">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="berbix-cordova-plugin" version="1.0.5">
   <name>Berbix Verify</name>
   <description>Cordova SDK for integrating with Berbix Verify</description>
   <license>Apache 2.0</license>
@@ -32,13 +32,6 @@
     </config-file>
     <source-file src="src/android/BerbixPlugin.java" target-dir="src/com/berbix/cordova" />
     <framework src="src/android/berbix.gradle" custom="true" type="gradleReference" />
-    <config-file target="AndroidManifest.xml" parent="/manifest">
-      <uses-permission android:name="android.permission.CAMERA"/>
-      <uses-feature android:name="android.hardware.camera" android:required="true"/>
-    </config-file>
-    <config-file target="AndroidManifest.xml" mode="merge" parent="/manifest/application">
-      <activity android:name="com.berbix.berbixverify.activities.BerbixActivity" android:theme="@style/Theme.AppCompat.Light"/>
-    </config-file>
     <framework src="com.berbix:berbixverify:1.3.0"/>
   </platform>
 </plugin>


### PR DESCRIPTION
1.0.5: remove duplicate manifest activity definition that can cause merge problems. 

https://developer.android.com/studio/build/manifest-merge

```
* What went wrong:
Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute activity#com.berbix.berbixverify.activities.BerbixActivity@theme value=(@style/Theme.AppCompat.Light) from AndroidManifest.xml:18:84-128
        is also present at [com.berbix:berbixverify:1.3.0] AndroidManifest.xml:18:13-52 value=(@style/BerbixThemeLight).
        Suggestion: add 'tools:replace="android:theme"' to <activity> element at AndroidManifest.xml:18:9-131 to override.
```

tested with a local demo cordova plugin