### PR TITLE
[rc2] fix ios podspec to include frameworks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "berbix-cordova-plugin",
-  "version": "2.0.0-rc01",
+  "version": "2.0.0-rc02",
   "description": "Cordova plugin for using the Berbix Verify flow.",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="berbix-cordova-plugin" version="2.0.0-rc01">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="berbix-cordova-plugin" version="2.0.0-rc02">
   <name>Berbix Verify</name>
   <description>Cordova SDK for integrating with Berbix Verify</description>
   <license>Apache 2.0</license>
@@ -19,7 +19,7 @@
         <source url="https://github.com/CocoaPods/Specs.git" />
         <source url="https://github.com/berbix/berbix-ios-spec.git"/>
       </config>
-      <pods>
+      <pods use-frameworks="true">
         <pod name="Berbix" spec="2.0.0-rc01" />
       </pods>
     </podspec>


### PR DESCRIPTION
fix ios podspec to include frameworks
https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#pods

```
SwiftyJSON/SwiftyJSON.modulemap'
      not found
```